### PR TITLE
Common jointjs reference

### DIFF
--- a/src/demo/app/editor.ts
+++ b/src/demo/app/editor.ts
@@ -19,8 +19,7 @@ import { Validators } from '@angular/forms';
 import { dia } from 'jointjs';
 import { BsModalService } from 'ngx-bootstrap';
 import { PropertiesDialogComponent } from './properties.dialog.component';
-import * as _joint from 'jointjs';
-const joint : any = _joint;
+const joint : any = Flo.joint;
 
 /**
  * @author Alex Boyko

--- a/src/demo/app/renderer.ts
+++ b/src/demo/app/renderer.ts
@@ -17,10 +17,9 @@
 import { Flo, Constants } from 'spring-flo';
 import { dia } from 'jointjs';
 
-import * as _joint from 'jointjs';
 const dagre = require('dagre');
 
-const joint : any = _joint;
+const joint : any = Flo.joint;
 
 
 const HANDLE_ICON_MAP = new Map<string, string>()

--- a/src/lib/src/editor/editor.component.ts
+++ b/src/lib/src/editor/editor.component.ts
@@ -7,11 +7,10 @@ import { Utils } from './editor.utils';
 import { CompositeDisposable, Disposable } from 'ts-disposables';
 import * as _$ from 'jquery';
 import * as _ from 'lodash';
-import * as _joint from 'jointjs';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-const joint : any = _joint;
+const joint : any = Flo.joint;
 const $ : any = _$;
 
 

--- a/src/lib/src/editor/editor.utils.ts
+++ b/src/lib/src/editor/editor.utils.ts
@@ -1,7 +1,7 @@
 import { dia } from 'jointjs';
+import { Flo } from './../shared/flo.common';
 import * as _ from 'lodash';
-import * as _joint from 'jointjs';
-const joint : any = _joint;
+const joint : any = Flo.joint;
 import * as _$ from 'jquery';
 const $ : any = _$;
 

--- a/src/lib/src/palette/palette.component.ts
+++ b/src/lib/src/palette/palette.component.ts
@@ -6,8 +6,7 @@ import { Flo } from './../shared/flo.common';
 import { Shapes, Constants } from './../shared/shapes';
 import { DOCUMENT } from '@angular/platform-browser'
 import * as _$ from 'jquery';
-import * as _joint from 'jointjs';
-const joint : any = _joint;
+const joint : any = Flo.joint;
 const $ : any = _$;
 
 const DEBOUNCE_TIME : number = 300;

--- a/src/lib/src/shared/flo.common.ts
+++ b/src/lib/src/shared/flo.common.ts
@@ -1,6 +1,10 @@
 import { dia } from 'jointjs';
 import { Observable } from 'rxjs/Observable';
+import * as _joint from 'jointjs';
+
 export namespace Flo {
+
+  export const joint : any = _joint;
 
   export enum DnDEventType {
     DRAG,

--- a/src/lib/src/shared/shapes.ts
+++ b/src/lib/src/shared/shapes.ts
@@ -2,9 +2,8 @@ import { dia } from 'jointjs';
 import { Flo } from './flo.common';
 import EditorDescriptor = Flo.ViewerDescriptor;
 import * as _ from 'lodash';
-import * as _joint from 'jointjs';
 import * as _$ from 'jquery';
-const joint : any = _joint;
+const joint : any = Flo.joint;
 const $ : any = _$;
 
 const isChrome : boolean = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);


### PR DESCRIPTION
Give all parts of the library and app a common reference to jointjs.
This change is meant to harden against build systems that might split
the reference when building.

fixes #17