### PR TITLE
Fix broken link formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Spring Flo is a JavaScript library that offers a basic embeddable HTML5 visual b
 
 [![dataflow ui](docs/Flo.png)](http://cloud.spring.io/spring-cloud-dataflow/)
 
-Here is a https://www.youtube.com/watch?v=78CgV46OstI[youtube video] of Spring Flo in action.
+Here is a [youtube video](https://www.youtube.com/watch?v=78CgV46OstI) of Spring Flo in action.
 
 ## Consuming Spring Flo
 
-Refer to the https://github.com/spring-projects/spring-flo/wiki[wiki] for more information on how to embed it in an application.
+Refer to the [wiki](https://github.com/spring-projects/spring-flo/wiki) for more information on how to embed it in an application.
 
 ## Build
 
@@ -18,16 +18,16 @@ Spring Flo is built using NPM commands. Simplest way to build is via `npm run bu
 
 ## Getting Help
 
-If you have any questions, issues, feedback or feature request please https://github.com/spring-projects/spring-flo/issues[raise an issue].
+If you have any questions, issues, feedback or feature request please [raise an issue](https://github.com/spring-projects/spring-flo/issues).
 
 ## Samples
 
-A small self contained sample usage of Spring Flo is available in the https://github.com/spring-projects/spring-flo/tree/master/src/demo[demo] sub folder. Execute `npm start` to run the sample. The https://github.com/spring-cloud/spring-cloud-dataflow-ui[Spring Cloud Data Flow UI] at github shows a larger scale usage of Spring Flo.
+A small self contained sample usage of Spring Flo is available in the [demo](https://github.com/spring-projects/spring-flo/tree/master/src/demo) sub folder. Execute `npm start` to run the sample. The [Spring Cloud Data Flow UI](https://github.com/spring-cloud/spring-cloud-dataflow-ui) at github shows a larger scale usage of Spring Flo.
 
 ## Contributing
 
-Pull requests are welcome, but before accepting them we will need you to sign the https://support.springsource.com/spring_committer_signup[Contributors Agreement].
+Pull requests are welcome, but before accepting them we will need you to sign the [Contributors Agreement](https://support.springsource.com/spring_committer_signup).
 
 ## License
 
-Spring Flo is Open Source software released under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
+Spring Flo is Open Source software released under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).


### PR DESCRIPTION
I assume this falls under "obvious fix".