### PR TITLE
URL Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 root = true
 
 [*]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Spring Flo is a JavaScript library that offers a basic embeddable HTML5 visual builder for pipelines and simple graphs. This library is used as the basis of the stream builder in Spring Cloud Data Flow.
 
-[![dataflow ui](docs/Flo.png)](http://cloud.spring.io/spring-cloud-dataflow/)
+[![dataflow ui](docs/Flo.png)](https://cloud.spring.io/spring-cloud-dataflow/)
 
 Here is a [youtube video](https://www.youtube.com/watch?v=78CgV46OstI) of Spring Flo in action.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "http://github.com/spring-projects/spring-flo.git"
+    "url": "https://github.com/spring-projects/spring-flo.git"
   },
   "engines": {
     "node": ">= 6.9.0",

--- a/src/lib/editor/editor.component.ts
+++ b/src/lib/editor/editor.component.ts
@@ -1117,7 +1117,7 @@ export class EditorComponent implements OnInit, OnDestroy {
   }
 
   initPaperListeners() {
-    // http://stackoverflow.com/questions/20463533/how-to-add-an-onclick-event-to-a-joint-js-element
+    // https://stackoverflow.com/questions/20463533/how-to-add-an-onclick-event-to-a-joint-js-element
     this.paper.on('cell:pointerclick', (cellView: dia.CellView) => {
         if (!this.readOnlyCanvas) {
           this.selection = cellView;
@@ -1168,7 +1168,7 @@ export class EditorComponent implements OnInit, OnDestroy {
       elementView: this.renderer && this.renderer.getNodeView ? this.renderer.getNodeView() : joint.shapes.flo.ElementView/*joint.dia.ElementView*/,
       linkView: this.renderer && this.renderer.getLinkView ? this.renderer.getLinkView() : joint.shapes.flo.LinkView,
       // Enable link snapping within 25px lookup radius
-      snapLinks: { radius: 25 }, // http://www.jointjs.com/tutorial/ports
+      snapLinks: { radius: 25 }, // https://www.jointjs.com/tutorial/ports
       defaultLink: /*this.renderer && this.renderer.createDefaultLink ? this.renderer.createDefaultLink: new joint.shapes.flo.Link*/
         (cellView: dia.CellView, magnet: SVGElement) => {
           if (this.renderer && this.renderer.createLink) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.jointjs.com/tutorial/ports (301) with 1 occurrences migrated to:  
  https://www.jointjs.com/tutorial/ports ([https](https://www.jointjs.com/tutorial/ports) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-dataflow/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-dataflow/ ([https](https://cloud.spring.io/spring-cloud-dataflow/) result 200).
* [ ] http://editorconfig.org with 1 occurrences migrated to:  
  https://editorconfig.org ([https](https://editorconfig.org) result 200).
* [ ] http://stackoverflow.com/questions/20463533/how-to-add-an-onclick-event-to-a-joint-js-element with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/20463533/how-to-add-an-onclick-event-to-a-joint-js-element ([https](https://stackoverflow.com/questions/20463533/how-to-add-an-onclick-event-to-a-joint-js-element) result 200).
* [ ] http://github.com/spring-projects/spring-flo.git with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-flo.git ([https](https://github.com/spring-projects/spring-flo.git) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/ with 1 occurrences